### PR TITLE
fix: scrollTop을 활용한 이전 페이지 마지막 스크롤 지점으로 이동 기능 수정

### DIFF
--- a/src/writeable/coinsWritable.ts
+++ b/src/writeable/coinsWritable.ts
@@ -1,5 +1,6 @@
 import { writable, type Writable } from "svelte/store";
 import type { CoinIF } from "../typescript/coins";
 
+export let lastScrollTop: Writable<number> = writable<number>(0);
 export let coinsWritable: Writable<CoinIF[]> = writable<CoinIF[]>([]);
 export let coinPageWritable: Writable<number[]> = writable<number[]>([0, 100]);


### PR DESCRIPTION
마지막으로 보고 있던 ScrollTop 좌표 값을 기억하고 이전 페이지로 돌아가는 경우, 화면 렌더링이 완료되는 대로 이전에 보고 있던 스크롤 위치로 이동 기능 추가.